### PR TITLE
Non-AJAX modes added

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -1,6 +1,7 @@
 <?php
 $conf['use_first_heading']= 1;
 $conf['namespace_in_tab'] = 0;
+$conf['ajax_init_page']   = 0;
 $conf['hideloading']      = 0;
 $conf['goto_link_header'] = 1;
 $conf['goto_link_footer'] = 1;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,6 +1,7 @@
 <?php
 $meta['use_first_heading']= array('onoff');
 $meta['namespace_in_tab'] = array('onoff');
+$meta['ajax_init_page']   = array('onoff');
 $meta['hideloading']      = array('onoff');
 $meta['goto_link_header'] = array('onoff');
 $meta['goto_link_footer'] = array('onoff');

--- a/helper.php
+++ b/helper.php
@@ -38,14 +38,102 @@ class helper_plugin_tabinclude extends DokuWiki_Plugin {
     }
 
 
+    /**
+     * Get Tabpages information
+     */
+    function getTabPages($match,$isInline=true){
+        global $ID;
+        $page_delim = $isInline?",":"\n";
+        list($class, $match) = explode('>', $match); // extract class
+        $class=trim($class);
+        $pages = explode($page_delim,$match); // extract page names
+        $sz = count($pages);
+        if($sz==0) return array();
+        $sz = count($pages);
+
+        // loop for tabs
+        $tabs = array();
+        $init_page_idx = 0; // initial page index
+        for($i=0;$i<$sz;$i++){
+            // Put page ID into $page
+            // Put text in tab into $title
+            $title='';
+            $page = trim($pages[$i]);
+
+            if($isInline){
+                // Inline description
+                if($page[0]=='*'){
+                    $init_page_idx=count($tabs);
+                    $page = substr($page,1);
+                }
+                $items = explode('|',$page);
+                if(count($items)>1){
+                    list($page,$title)=$items;
+                }
+            }else{
+                // Lines description
+
+                if (preg_match('/\[\[(.+?)\]\]/', $page, $match)){
+                    // Pagelist like syntax,
+                    // each tabbed page is provided as DokuWiki unordered list syntax:
+                    // *[[id|title]] or **[[id|title]].
+                    $p = substr($page,0,strpos($page,'[['));
+                    $page = $match[1];
+                    if($page=='') continue;
+                    if (strpos($p,'*') !== strrpos($p,'*')) {
+                        // multiple '*' means initial page!!
+                        $init_page_idx = count($tabs);
+                    }
+                } else {
+                    // original syntax
+                    $asterisk = false;
+                    while($page[0]=='*'){
+                        $page = substr($page,1);
+                        $asterisk = true;
+                    }
+                    if($page=='') continue;
+                    if($asterisk) $init_page_idx = count($tabs);
+                }
+                list($page, $title) = explode('|', $page, 2);
+                list($page ,$section) = explode('#', $page, 2);
+                if($page=='') continue;
+            }
+
+            // Show namespace(s) of page name in tab ?
+            resolve_pageid(getNS($ID),$page,$exists);
+            if($title==''){
+                $title = $this->getConf('namespace_in_tab')?$page:noNS($page);
+            }
+            // Show first heading as tab name ?
+            if($this->getConf('use_first_heading')){
+                $meta_title= p_get_metadata($page,'title');
+                if($meta_title!=''){
+                    $title = $meta_title;
+                }
+            }
+
+            // Check errors
+            if(page_exists($page)==false){
+                // page in tab exists ?
+                $tabs[] = array('error'=>tpl_link(wl($page),$page,'',true).' - '.$this->getLang('error_notfound'));
+            }else if($ID==$page){
+                // page is identical to parent ?
+                $tabs[] = array('error'=>$this->getLang('error_parent'));
+            }else{
+                $tabs[] = array('page'=>hsc($page),'title'=>hsc($title));
+            }
+        }
+        return array($state,$tabs,$init_page_idx,hsc(trim($class)));
+    }
 
     /**
-     * Get tab XHTML from pagenames
+     * Get AJAX tab XHTML from pagenames
      */
     function renderTabsHtml(&$renderer,$tabs,$init_page_idx,$class='') {
         // render
         if($class) $class=' class="'.$class.'"';
         $html.= '<div id="dwpl-ti-container"'.$class.'>'.NL;
+
         $html.='<ul class="dwpl-ti">'.NL;
         $sz = count($tabs);
         for($i=0;$i<$sz;$i++){
@@ -62,6 +150,59 @@ class helper_plugin_tabinclude extends DokuWiki_Plugin {
             $html.='<div id="dwpl-ti-loading" class="dwpl-ti-loading">'.$this->getLang('loading').'</div>';
         }
         $html.='<div id="dwpl-ti-content" class="dwpl-ti-content">';
+        if($this->getConf('ajax_init_page')!=0){
+            $html.='<div id="dwpl-ti-read-init-page" class="hidden" value="'.$tabs[$init_page_idx]['page'].'"></div>';
+        }
+
+        $goto = $this->getLang('gotohere');
+        $pagelink = tpl_link(wl($tabs[$init_page_idx]['page']),$goto,'',true);
+        if($this->getConf('goto_link_header')!=0)
+            $html.= '<div class="dwpl-ti-permalink-header">'.$pagelink.'</div>'.NL;
+        if($this->getConf('ajax_init_page')==0){
+            $html.=tpl_include_page($tabs[$init_page_idx]['page'],false);
+        }
+        if($this->getConf('goto_link_footer')!=0)
+            $html.= '<div class="dwpl-ti-permalink-footer">'.$pagelink.'</div>'.NL;
+        $html.= '</div></div>'.NL.'</div>'.NL;
+
+
+        $renderer->doc.=$html;
+
+        global $conf;
+        if($conf['allowdebug']==1){
+            $renderer->doc.="<!-- \n".print_r(array($tabs,$init_page_idx,$class),true)."\n -->";
+        }
+
+        return true;
+    }
+    /**
+     * Get links of tab XHTML from pagenames
+     */
+    function renderLinkTabs(&$renderer,$tabs,$init_page_idx,$class='') {
+        global $ID;
+        // Selected page defined ?
+        if(isset($_GET['tabpage_idx'])) $init_page_idx = $_GET['tabpage_idx'];
+
+        // render
+        if($class) $class=' class="'.$class.'"';
+        $html.= '<div id="dwpl-ti-container"'.$class.'>'.NL;
+        $html.='<ul class="dwpl-ti">'.NL;
+        $sz = count($tabs);
+        for($i=0;$i<$sz;$i++){
+            if(empty($tabs[$i]['error'])){
+                $selected_class=($init_page_idx==$i)?' selected':'';
+                $html.='<li class="dwpl-ti-tab">';
+                $html.=tpl_link(wl($ID,'tabpage_idx='.$i.'#dokuwiki__content'),$tabs[$i]['title'],'class="'.$selected_class.'"',true);
+                $html.='</li>'.NL;
+            }else{
+                $html.='<li class="dwpl-ti-tab">';
+                $html.='<div class="dwpl-ti-tab-title error">'.$tabs[$i]['error'].'</div>';
+                $html.='</li>'.NL;
+            }
+        }
+        $html.= '</ul>'.NL;
+        $html.='<div class="dwpl-ti-content-box">';
+        $html.='<div id="dwpl-ti-content" class="dwpl-ti-content">';
 
         $goto = $this->getLang('gotohere');
         $pagelink = tpl_link(wl($tabs[$init_page_idx]['page']),$goto,'',true);
@@ -71,6 +212,62 @@ class helper_plugin_tabinclude extends DokuWiki_Plugin {
         if($this->getConf('goto_link_footer')!=0)
             $html.= '<div class="dwpl-ti-permalink-footer">'.$pagelink.'</div>'.NL;
         $html.= '</div></div>'.NL.'</div>'.NL;
+
+        $renderer->doc.=$html;
+
+        global $conf;
+        if($conf['allowdebug']==1){
+            $renderer->doc.="<!-- \n".print_r(array($tabs,$init_page_idx,$class),true)."\n -->";
+        }
+
+        return true;
+    }
+
+    /**
+     * Get embed tabs XHTML from pagenames
+     */
+    function renderEmbedTabs(&$renderer,$tabs,$init_page_idx,$class='') {
+        global $ID;
+        // Selected page defined ?
+        if(isset($_GET['tabpage_idx'])) $init_page_idx = $_GET['tabpage_idx'];
+
+        // render all tabs !
+        if($class) $class=' class="'.$class.'"';
+        $html.= '<div id="dwpl-ti-container"'.$class.'>'.NL;
+        $html.='<ul class="dwpl-ti">'.NL;
+        $sz = count($tabs);
+        for($i=0;$i<$sz;$i++){
+            if(empty($tabs[$i]['error'])){
+                $selected_class=($init_page_idx==$i)?' selected':'';
+                $html.='<li class="dwpl-ti-tab">';
+                $html.='<div class="dwpl-ti-tab-embd-title'.$selected_class.'">'.$tabs[$i]['title'].'</div></li>'.NL;
+                $html.='</li>'.NL;
+            }else{
+                $html.='<li class="dwpl-ti-tab">';
+                $html.='<div class="dwpl-ti-tab-title error">'.$tabs[$i]['error'].'</div>';
+                $html.='</li>'.NL;
+            }
+        }
+        $html.= '</ul>'.NL;
+        $html.='<div class="dwpl-ti-content-box">';
+
+        for($i=0;$i<$sz;$i++){
+            $html.='<div id="dwpl-ti-content" class="dwpl-ti-content">';
+            if($i==$init_page_idx)
+                $html.='<div class="dwpl-ti-tab-embd">';
+            else
+                $html.='<div class="dwpl-ti-tab-embd hidden">';
+            $goto = $this->getLang('gotohere');
+            $pagelink = tpl_link(wl($tabs[$i]['page']),$goto,'',true);
+            if($this->getConf('goto_link_header')!=0)
+                $html.= '<div class="dwpl-ti-permalink-header">'.$pagelink.'</div>'.NL;
+            $html.=tpl_include_page($tabs[$i]['page'],false);
+            if($this->getConf('goto_link_footer')!=0)
+                $html.= '<div class="dwpl-ti-permalink-footer">'.$pagelink.'</div>'.NL;
+            $html.= '</div></div>'.NL;
+        }
+        $html.='</div>'.NL;
+        $html.='</div>'.NL;
 
         $renderer->doc.=$html;
 

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,6 +1,7 @@
 <?php
 $lang['use_first_heading']= 'Use first heading in tab';
 $lang['namespace_in_tab'] = 'Include namespaces for page ID';
-$lang['hideloading']      = 'Hide loading message';
+$lang['hideloading']      = 'Hide loading message (AJAX mode)';
+$lang['ajax_init_page']   = 'Read initial tab page by AJAX (AJAX mode)';
 $lang['goto_link_header'] = 'Show page link at header';
 $lang['goto_link_footer'] = 'Show page link at footer';

--- a/lang/ja/settings.php
+++ b/lang/ja/settings.php
@@ -1,6 +1,7 @@
 <?php
 $lang['use_first_heading']= 'タブには最初の見出しを使う';
 $lang['namespace_in_tab'] = 'ページ名には名前空間も含める';
-$lang['hideloading']      = 'Loadingメッセージを隠す';
+$lang['ajax_init_page']   = '初期ページにAJAXを使う (AJAXモード)';
+$lang['hideloading']      = 'Loadingメッセージを隠す (AJAXモード)';
 $lang['goto_link_header'] = 'リンクを表示(ヘッダ)';
 $lang['goto_link_footer'] = 'リンクを表示(フッタ)';

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   tabinclude
 author Ikuo Obataya
 email  i.obataya[at]gmail_com
-date   2013-02-05
+date   2014-06-20
 name   Tab include plugin
 desc   Tab control of wiki pages
 url    http://www.dokuwiki.org/plugin:tabinclude

--- a/script.js
+++ b/script.js
@@ -23,15 +23,25 @@ function dwpl_ti_refresh(_this, page){
  * Initial process
  */
 function dwpl_ti_init(){
-    // set event handler
-    jQuery('ul.dwpl-ti li div.dwpl-ti-tab-title').each(function(){
-        jQuery(this).click(function(){
-            // unselect all tabs
-            jQuery('.dwpl-ti-tab-title').removeClass('selected');
-            // select a tab
-            jQuery(this).addClass('selected');
-            dwpl_ti_refresh(jQuery(this), jQuery(this).attr('value'));
-        });
+    // Click event for AJAX tabs
+    jQuery('ul.dwpl-ti li div.dwpl-ti-tab-title').click(function(){
+        jQuery('.dwpl-ti-tab-title').removeClass('selected');
+        jQuery(this).addClass('selected');
+        dwpl_ti_refresh(jQuery(this), jQuery(this).attr('value'));
+    });
+    // Show initial page if necessary
+    var init_ajax=jQuery('#dwpl-ti-read-init-page');
+    if(init_ajax){
+        dwpl_ti_refresh(init_ajax,init_ajax.attr('value'));
+    }
+
+    // Click event for Embedded tabs
+    jQuery(".dwpl-ti-tab-embd-title").click(function() {
+        var num = jQuery(".dwpl-ti-tab-embd-title").index(this);
+        jQuery(".dwpl-ti-tab-embd-title").removeClass('selected');
+        jQuery(this).addClass('selected');
+        jQuery(".dwpl-ti-tab-embd").addClass('hidden');
+        jQuery(".dwpl-ti-tab-embd").eq(num).removeClass('hidden');
     });
 }
 jQuery(function(){dwpl_ti_init();});

--- a/style.css
+++ b/style.css
@@ -39,18 +39,24 @@ div#dwpl-ti-container li.dwpl-ti-tab {
   margin:0 0.5em;
 }
 
+div#dwpl-ti-container li.dwpl-ti-tab a{
+  color: __text_alt__;
+}
+
 div#dwpl-ti-container li.dwpl-ti-tab:hover {
   background-color:__background_alt__;
   text-decoration:underline;
 }
 
-div#dwpl-ti-container li.dwpl-ti-tab div.dwpl-ti-tab-title{
+div#dwpl-ti-container li.dwpl-ti-tab div
+{
   margin:0;
   padding:0;
   cursor:pointer;
 }
 
-div#dwpl-ti-container li.dwpl-ti-tab div.dwpl-ti-tab-title.selected{
+div#dwpl-ti-container li.dwpl-ti-tab .selected
+{
   color:__text__;
 }
 div#dwpl-ti-container li.dwpl-ti-tab div.error

--- a/syntax/embed.php
+++ b/syntax/embed.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Ikuo Obataya (i.obataya[at]gmail.com)
+ */
+if(!defined('DOKU_INC')) die();
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
+@require_once(DOKU_PLUGIN.'syntax.php');
+/**
+ * Tab plugin
+ */
+class syntax_plugin_tabinclude_embed extends DokuWiki_Syntax_Plugin{
+  function __construct(){
+      $this->helper = plugin_load('helper','tabinclude');
+  }
+  function getType(){ return 'substition'; }
+  function getSort(){ return 158; }
+  function connectTo($mode){$this->Lexer->addSpecialPattern('\{\{tabembed.+?[^}]*\}\}',$mode,'plugin_tabinclude_embed');}
+ /**
+  * handle syntax
+  */
+  function handle($match, $state, $pos, &$handler){
+      $match = substr($match,10,-2); // strip markup
+      return $this->helper->getTabPages($match);
+  }
+ /**
+  * Render tab control
+  */
+  function render($mode, &$renderer, $data) {
+      list($state, $tabs,$init_page_idx,$class) = $data;
+      if ($mode=='xhtml'){
+          $this->helper->renderEmbedTabs($renderer,$tabs,$init_page_idx,$class);
+          return true;
+      }else if($mode=='odt'){
+          $this->helper->getOdtHtml($renderer,$tabs);
+          return true;
+      }
+      return false;
+  }
+}
+?>

--- a/syntax/inline.php
+++ b/syntax/inline.php
@@ -10,76 +10,34 @@ if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
  * Tab plugin
  */
 class syntax_plugin_tabinclude_inline extends DokuWiki_Syntax_Plugin{
-  function getType(){ return 'substition'; }
-  function getSort(){ return 158; }
-  function connectTo($mode){$this->Lexer->addSpecialPattern('\{\{tabinclude>[^}]*\}\}',$mode,'plugin_tabinclude_inline');}
- /**
-  * handle syntax
-  */
-  function handle($match, $state, $pos, &$handler){
-    global $ID;
-    $match = substr($match,13,-2);
-    $pages = explode(',',$match);
-    $sz = count($pages);
-    if($sz==0) return array();
-
-    // loop for tabs
-    $tabs = array();
-    $init_page_idx = 0; // initial page index
-    for($i=0;$i<$sz;$i++){
-        // Put page ID into $page
-        // Put text in tab into $title
-        $title='';
-        $page = trim($pages[$i]);
-        if($page[0]=='*'){
-            $init_page_idx=count($tabs);
-            $page = substr($page,1);
-        }
-        $items = explode('|',$page);
-        if(count($items)>1){
-            list($page,$title)=$items;
-        }
-
-        // Show namespace(s) of page name in tab ?
-        resolve_pageid(getNS($ID),$page,$exists);
-        if($title==''){
-            $title = $this->getConf('namespace_in_tab')?$page:noNS($page);
-        }
-        // Show first heading as tab name ?
-        if($this->getConf('use_first_heading')){
-            $meta_title= p_get_metadata($page,'title');
-            if($meta_title!=''){
-                $title = $meta_title;
-            }
-        }
-
-        // Check errors
-        if(page_exists($page)==false){
-            // page in tab exists ?
-            $tabs[] = array('error'=>$this->getLang('error_notfound'));
-        }else if($ID==$page){
-            // page is identical to parent ?
-            $tabs[] = array('error'=>$this->getLang('error_parent'));
-        }else{
-            $tabs[] = array('page'=>hsc($page),'title'=>hsc($title));
-        }
+    function __construct(){
+        $this->helper = plugin_load('helper','tabinclude');
     }
-    return array($state,$tabs,$init_page_idx,"");
-  }
- /**
-  * Render tab control
-  */
-  function render($mode, &$renderer, $data) {
-      $helper = plugin_load('helper','tabinclude');
-      list($state, $tabs,$init_page_idx,$class) = $data;
-      if ($mode=='xhtml'){
-          $helper->renderTabsHtml($renderer,$tabs,$init_page_idx,$class);
-          return true;
-      }else if($mode=='odt'){
-          $helper->getOdtHtml($renderer,$tabs);
-          return true;
-      }
-      return false;
-  }
+    function getType(){ return 'substition'; }
+    function getSort(){ return 158; }
+    function connectTo($mode){$this->Lexer->addSpecialPattern('\{\{tabinclude.+?[^}]*\}\}',$mode,'plugin_tabinclude_inline');}
+
+    /**
+     * handle syntax
+     */
+    function handle($match, $state, $pos, &$handler){
+        $match = substr($match,12,-2); // strip markup
+        return $this->helper->getTabPages($match); // inline mode
+    }
+
+    /**
+     * Render tab control
+     */
+    function render($mode, &$renderer, $data) {
+        list($state, $tabs,$init_page_idx,$class) = $data;
+        if ($mode=='xhtml'){
+            $this->helper->renderTabsHtml($renderer,$tabs,$init_page_idx,$class);
+            return true;
+        }else if($mode=='odt'){
+            $this->helper->getOdtHtml($renderer,$tabs);
+            return true;
+        }
+        return false;
+    }
 }
 ?>

--- a/syntax/lines.php
+++ b/syntax/lines.php
@@ -12,6 +12,9 @@ if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
  * provided by satoshi.sahara@gmail.com
 */
 class syntax_plugin_tabinclude_lines extends DokuWiki_Syntax_Plugin{
+    function __construct(){
+        $this->helper = plugin_load('helper','tabinclude');
+    }
     function getType(){ return 'substition'; }
     function getSort(){ return 158; }
     function connectTo($mode){
@@ -21,83 +24,19 @@ class syntax_plugin_tabinclude_lines extends DokuWiki_Syntax_Plugin{
      * handle syntax
      */
     function handle($match, $state, $pos, &$handler){
-        global $ID;  //SAHARA : required for resolve_pageid()
         $match = substr($match,7,-9);  // strip markup
-        list($class, $match) = explode('>', $match); // extract class
-        $pages = explode("\n", $match);
-        $sz = count($pages);
-        if($sz==0) return array();
-
-        // loop for tabs
-        $tabs = array();
-        $init_page_idx = 0;  // initial page index
-        for($i=0; $i<$sz; $i++){
-            // Put page ID into $page
-            // Put text in tab into $title
-            $page = trim($pages[$i]);
-
-            if (preg_match('/\[\[(.+?)\]\]/', $page, $match)){
-                // Pagelist like syntax,
-                // each tabbed page is provided as DokuWiki unordered list syntax:
-                // *[[id|title]] or **[[id|title]].
-                $p = substr($page,0,strpos($page,'[['));
-                $page = $match[1];
-                if($page=='') continue;
-                if (strpos($p,'*') !== strrpos($p,'*')) {
-                    // multiple '*' means initial page!!
-                    $init_page_idx = count($tabs);
-                }
-            } else {
-                // original syntax
-                $asterisk = false;
-                while($page[0]=='*'){
-                    $page = substr($page,1);
-                    $asterisk = true;
-                }
-                if($page=='') continue;
-                if($asterisk) $init_page_idx = count($tabs);
-            }
-            list($page, $title) = explode('|', $page, 2);
-            list($page ,$section) = explode('#', $page, 2);
-            if($page=='') continue;
-
-            // Show namespace(s) of page name in tab ?
-            resolve_pageid(getNS($ID),$page,$exists);
-            if($title==''){
-                $title = $this->getConf('namespace_in_tab')?$page:noNS($page);
-            }
-            // Show first heading as tab name ?
-            if($this->getConf('use_first_heading')){
-                $meta_title= p_get_metadata($page,'title');
-                if($meta_title!=''){
-                    $title = $meta_title;
-                }
-            }
-
-            // Check errors
-            if(page_exists($page)==false){
-                // page in tab exists ?
-                $tabs[] = array('error'=>$this->getLang('error_notfound'));
-            }else if($ID==$page){
-                // page is identical to parent ?
-                $tabs[] = array('error'=>$this->getLang('error_parent'));
-            }else{
-                $tabs[] = array('page'=>hsc($page),'title'=>hsc($title));
-            }
-        }
-        return array($state,$tabs,$init_page_idx,hsc(trim($class)));
+        return $this->helper->getTabPages($match,false);
     }
     /**
      * Render tab control
      */
     function render($mode, &$renderer, $data) {
-        $helper = plugin_load('helper','tabinclude');
         list($state, $tabs,$init_page_idx,$class) = $data;
         if ($mode=='xhtml'){
-            $helper->renderTabsHtml($renderer,$tabs,$init_page_idx,$class);
+            $this->helper->renderTabsHtml($renderer,$tabs,$init_page_idx,$class);
             return true;
         }else if($mode=='odt'){
-            $helper->getOdtHtml($renderer,$tabs);
+            $this->helper->getOdtHtml($renderer,$tabs);
             return true;
         }
         return false;

--- a/syntax/link.php
+++ b/syntax/link.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Ikuo Obataya (i.obataya[at]gmail.com)
+ */
+if(!defined('DOKU_INC')) die();
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
+@require_once(DOKU_PLUGIN.'syntax.php');
+/**
+ * Tab plugin
+ */
+class syntax_plugin_tabinclude_link extends DokuWiki_Syntax_Plugin{
+    function __construct(){
+        $this->helper = plugin_load('helper','tabinclude');
+    }
+    function getType(){ return 'substition'; }
+  function getSort(){ return 158; }
+  function connectTo($mode){$this->Lexer->addSpecialPattern('\{\{tablink.+?[^}]*\}\}',$mode,'plugin_tabinclude_link');}
+ /**
+  * handle syntax
+  */
+  function handle($match, $state, $pos, &$handler){
+    $match = substr($match,9,-2); // strip markup
+    return $this->helper->getTabPages($match);
+  }
+ /**
+  * Render tab control
+  */
+  function render($mode, &$renderer, $data) {
+      list($state, $tabs,$init_page_idx,$class) = $data;
+      if ($mode=='xhtml'){
+          $this->helper->renderLinkTabs($renderer,$tabs,$init_page_idx,$class);
+          return true;
+      }else if($mode=='odt'){
+          $this->helper->getOdtHtml($renderer,$tabs);
+          return true;
+      }
+      return false;
+  }
+}
+?>


### PR DESCRIPTION
Two modes without AJAX were added in order to evade issues due to
JavaScripts.

Since tab showed only a dokuwiki contents read by AJAX, JavaScripts
registered to onLoad didn't run on clicking tab.
{{tablink>page1,page2,..}}  shows a selected tab with page transition on
clicking.
{{tabembed>>page1,page2,...}} shows a selected tab, while all contents
of tabs are embedded in the page.
