### PR TITLE
Rename renderTabsOdt to getOdtHtml

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -26,7 +26,7 @@ class helper_plugin_tabinclude extends DokuWiki_Plugin {
                 'return' => array('html' => 'string'),
         );
         $result[] = array(
-                'name'   => 'renderTabsOdt',
+                'name'   => 'getOdtHtml',
                 'desc'   => 'Render tabs ODT of DokuWiki pages',
                 'params' => array(
                         'renderer' => 'renderer',
@@ -285,7 +285,7 @@ class helper_plugin_tabinclude extends DokuWiki_Plugin {
     /**
      * Get tab ODT from pagenames
      */
-    function renderTabsOdt(&$renderer,$tabs){
+    function getOdtHtml(&$renderer,$tabs){
         $renderer->strong_open();
         $renderer->doc.='Tab pages';
         $renderer->strong_close();


### PR DESCRIPTION
As the syntax plugins call getOdtHtml and not renderTabsOdt

attempt to 
close #46