### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/embed.php
+++ b/syntax/embed.php
@@ -19,14 +19,14 @@ class syntax_plugin_tabinclude_embed extends DokuWiki_Syntax_Plugin{
  /**
   * handle syntax
   */
-  function handle($match, $state, $pos, &$handler){
+  function handle($match, $state, $pos, Doku_Handler $handler){
       $match = substr($match,10,-2); // strip markup
       return $this->helper->getTabPages($match);
   }
  /**
   * Render tab control
   */
-  function render($mode, &$renderer, $data) {
+  function render($mode, Doku_Renderer $renderer, $data) {
       list($state, $tabs,$init_page_idx,$class) = $data;
       if ($mode=='xhtml'){
           $this->helper->renderEmbedTabs($renderer,$tabs,$init_page_idx,$class);

--- a/syntax/inline.php
+++ b/syntax/inline.php
@@ -20,7 +20,7 @@ class syntax_plugin_tabinclude_inline extends DokuWiki_Syntax_Plugin{
     /**
      * handle syntax
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         $match = substr($match,12,-2); // strip markup
         return $this->helper->getTabPages($match); // inline mode
     }
@@ -28,7 +28,7 @@ class syntax_plugin_tabinclude_inline extends DokuWiki_Syntax_Plugin{
     /**
      * Render tab control
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         list($state, $tabs,$init_page_idx,$class) = $data;
         if ($mode=='xhtml'){
             $this->helper->renderTabsHtml($renderer,$tabs,$init_page_idx,$class);

--- a/syntax/lines.php
+++ b/syntax/lines.php
@@ -23,14 +23,14 @@ class syntax_plugin_tabinclude_lines extends DokuWiki_Syntax_Plugin{
     /**
      * handle syntax
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         $match = substr($match,7,-9);  // strip markup
         return $this->helper->getTabPages($match,false);
     }
     /**
      * Render tab control
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         list($state, $tabs,$init_page_idx,$class) = $data;
         if ($mode=='xhtml'){
             $this->helper->renderTabsHtml($renderer,$tabs,$init_page_idx,$class);

--- a/syntax/link.php
+++ b/syntax/link.php
@@ -19,14 +19,14 @@ class syntax_plugin_tabinclude_link extends DokuWiki_Syntax_Plugin{
  /**
   * handle syntax
   */
-  function handle($match, $state, $pos, &$handler){
+  function handle($match, $state, $pos, Doku_Handler $handler){
     $match = substr($match,9,-2); // strip markup
     return $this->helper->getTabPages($match);
   }
  /**
   * Render tab control
   */
-  function render($mode, &$renderer, $data) {
+  function render($mode, Doku_Renderer $renderer, $data) {
       list($state, $tabs,$init_page_idx,$class) = $data;
       if ($mode=='xhtml'){
           $this->helper->renderLinkTabs($renderer,$tabs,$init_page_idx,$class);


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.