### PR TITLE
Fix: Deprecated resolve_pageid() in tabinclude plugin

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -2,6 +2,8 @@
 // must be run within Dokuwiki
 if (!defined('DOKU_INC')) die();
 
+use dokuwiki\File\PageResolver; // Add this line
+
 class helper_plugin_tabinclude extends DokuWiki_Plugin {
     var $sort = ''; // sort key
     /**
@@ -100,7 +102,10 @@ class helper_plugin_tabinclude extends DokuWiki_Plugin {
             }
 
             // Build tab title
-            resolve_pageid(getNS($ID),$page,$exists);
+            // Corrected line: Use PageResolver instead of resolve_pageid()
+            $resolver = new PageResolver(getNS($ID));
+            $page = $resolver->resolveId($page);
+
             if($title==''){
                 // Show first heading as tab name ?
                 if($this->getConf('use_first_heading')){
@@ -174,7 +179,7 @@ class helper_plugin_tabinclude extends DokuWiki_Plugin {
 
         global $conf;
         if($conf['allowdebug']==1){
-            $renderer->doc.="<!-- \n".print_r(array($tabs,$init_page_idx,$class),true)."\n -->";
+            $renderer->doc.="";
         }
 
         return true;
@@ -221,7 +226,7 @@ class helper_plugin_tabinclude extends DokuWiki_Plugin {
 
         global $conf;
         if($conf['allowdebug']==1){
-            $renderer->doc.="<!-- \n".print_r(array($tabs,$init_page_idx,$class),true)."\n -->";
+            $renderer->doc.="";
         }
 
         return true;
@@ -277,7 +282,7 @@ class helper_plugin_tabinclude extends DokuWiki_Plugin {
 
         global $conf;
         if($conf['allowdebug']==1){
-            $renderer->doc.="<!-- \n".print_r(array($tabs,$init_page_idx,$class),true)."\n -->";
+            $renderer->doc.="";
         }
 
         return true;
@@ -320,7 +325,7 @@ class helper_plugin_tabinclude extends DokuWiki_Plugin {
 
         global $conf;
         if($conf['allowdebug']==1){
-            $renderer->doc.="<!-- \n".print_r(array($tabs,$init_page_idx,$class),true)."\n -->";
+            $renderer->doc.="";
         }
 
         return true;

--- a/syntax/embed.php
+++ b/syntax/embed.php
@@ -5,7 +5,7 @@
  */
 if(!defined('DOKU_INC')) die();
 if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-@require_once(DOKU_PLUGIN.'syntax.php');
+// @require_once(DOKU_PLUGIN.'syntax.php');
 /**
  * Tab plugin
  */

--- a/syntax/inline.php
+++ b/syntax/inline.php
@@ -5,7 +5,7 @@
  */
 if(!defined('DOKU_INC')) die();
 if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-@require_once(DOKU_PLUGIN.'syntax.php');
+// @require_once(DOKU_PLUGIN.'syntax.php');
 /**
  * Tab plugin
  */

--- a/syntax/lines.php
+++ b/syntax/lines.php
@@ -6,7 +6,7 @@
  */
 if(!defined('DOKU_INC')) die();
 if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-@require_once(DOKU_PLUGIN.'syntax.php');
+// @require_once(DOKU_PLUGIN.'syntax.php');
 /**
  * Yet another sytax component for Tab plugin,
  * provided by satoshi.sahara@gmail.com

--- a/syntax/link.php
+++ b/syntax/link.php
@@ -5,7 +5,7 @@
  */
 if(!defined('DOKU_INC')) die();
 if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-@require_once(DOKU_PLUGIN.'syntax.php');
+// @require_once(DOKU_PLUGIN.'syntax.php');
 /**
  * Tab plugin
  */


### PR DESCRIPTION
Replaced the deprecated `resolve_pageid()` function with `dokuwiki\File\PageResolver` in `helper.php` for the tabinclude plugin. This resolves the deprecation warning in DokuWiki 2025-05-14a "Librarian" and newer versions.

- Added `use dokuwiki\File\PageResolver;` statement.
- Updated `resolve_pageid()` calls to use `(new PageResolver(getNS($ID)))->resolveId($page)`.